### PR TITLE
Fix install target for libOpenNI2Orbbec.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ install(TARGETS astra_wrapper astra_camera_nodelet astra_camera_node astra_list_
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   )
 
-install(FILES ${CMAKE_BINARY_DIR}/openni2/Redist/libOpenNI2Orbbec.so
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openni2/Redist/libOpenNI2Orbbec.so
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}/
 )
 


### PR DESCRIPTION
Without this patch, the following command fails:

    catkin_make --pkg astra_camera install

The error message is:

    CMake Error at cmake_install.cmake:201 (FILE):
      file INSTALL cannot find
      "/home/martin/ros-indigo-ws/build/openni2/Redist/libOpenNI2Orbbec.so".

This is because:

    CMAKE_BINARY_DIR:         /home/martin/ros-indigo-ws/build
    CMAKE_CURRENT_BINARY_DIR: /home/martin/ros-indigo-ws/build/ros_astra_camera

... and the file is in `/home/martin/ros-indigo-ws/build/ros_astra_camera/openni2/Redist/libOpenNI2Orbbec.so`.