### PR TITLE
safely handle missing params bootorder and devnums

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>astra_camera</name>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>Drivers for Orbbec Astra Devices. </description>
   <author email="liuhua@orbbec.com">Tim Liu</author>
   <license>BSD</license>

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -67,8 +67,14 @@ AstraDriver::AstraDriver(ros::NodeHandle& n, ros::NodeHandle& pnh) :
 
 #if MULTI_ASTRA
 	int bootOrder, devnums;
-	pnh.getParam("bootorder", bootOrder);
-	pnh.getParam("devnums", devnums);
+	if (!pnh.getParam("bootorder", bootOrder))
+       {
+              bootOrder = 0;
+       }
+	if (!pnh.getParam("devnums", devnums))
+       {
+              devnums = 1;
+       }
 	if( devnums>1 )
 	{
 		int shmid;


### PR DESCRIPTION
before the change, local variables will be left uninitialized when those two params are missing.