### PR TITLE
Publish projector/camera_info (fixes disparity img)

### DIFF
--- a/include/astra_camera/astra_device.h
+++ b/include/astra_camera/astra_device.h
@@ -123,6 +123,7 @@ public:
   float getIRFocalLength (int output_y_resolution) const;
   float getColorFocalLength (int output_y_resolution) const;
   float getDepthFocalLength (int output_y_resolution) const;
+  float getBaseline () const;
 
   void setAutoExposure(bool enable) throw (AstraException);
   void setAutoWhiteBalance(bool enable) throw (AstraException);

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -77,6 +77,7 @@ private:
   sensor_msgs::CameraInfoPtr getColorCameraInfo(int width, int height, ros::Time time) const;
   sensor_msgs::CameraInfoPtr getIRCameraInfo(int width, int height, ros::Time time) const;
   sensor_msgs::CameraInfoPtr getDepthCameraInfo(int width, int height, ros::Time time) const;
+  sensor_msgs::CameraInfoPtr getProjectorCameraInfo(int width, int height, ros::Time time) const;
 
   void readConfigFromParameterServer();
 
@@ -170,6 +171,7 @@ private:
   bool color_subscribers_;
   bool depth_subscribers_;
   bool depth_raw_subscribers_;
+  bool projector_info_subscribers_;
 
   bool use_device_time_;
 

--- a/src/astra_device.cpp
+++ b/src/astra_device.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "openni2/OpenNI.h"
+#include <openni2/PS1080.h> // For XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE property
 
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/replace.hpp>
@@ -171,6 +172,20 @@ float AstraDevice::getDepthFocalLength(int output_y_resolution) const
   }
 
   return focal_length;
+}
+
+float AstraDevice::getBaseline() const
+{
+  float baseline = 0.075f;
+  boost::shared_ptr<openni::VideoStream> stream = getDepthVideoStream();
+
+  if (stream && stream->isPropertySupported(XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE))
+  {
+    double baseline_meters;
+    stream->getProperty(XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE, &baseline_meters); // Device specific -- from PS1080.h
+    baseline = static_cast<float>(baseline_meters * 0.01f);  // baseline from cm -> meters
+  }
+  return baseline;
 }
 
 bool AstraDevice::isIRVideoModeSupported(const AstraVideoMode& video_mode) const

--- a/src/astra_device.cpp
+++ b/src/astra_device.cpp
@@ -31,7 +31,6 @@
  */
 
 #include "openni2/OpenNI.h"
-#include <openni2/PS1080.h> // For XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE property
 
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/replace.hpp>
@@ -176,16 +175,7 @@ float AstraDevice::getDepthFocalLength(int output_y_resolution) const
 
 float AstraDevice::getBaseline() const
 {
-  float baseline = 0.075f;
-  boost::shared_ptr<openni::VideoStream> stream = getDepthVideoStream();
-
-  if (stream && stream->isPropertySupported(XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE))
-  {
-    double baseline_meters;
-    stream->getProperty(XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE, &baseline_meters); // Device specific -- from PS1080.h
-    baseline = static_cast<float>(baseline_meters * 0.01f);  // baseline from cm -> meters
-  }
-  return baseline;
+  return 0.075f;
 }
 
 bool AstraDevice::isIRVideoModeSupported(const AstraVideoMode& video_mode) const

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -153,6 +153,7 @@ void AstraDriver::advertiseROSTopics()
   image_transport::ImageTransport depth_it(depth_nh);
   ros::NodeHandle depth_raw_nh(nh_, "depth");
   image_transport::ImageTransport depth_raw_it(depth_raw_nh);
+  ros::NodeHandle projector_nh(nh_, "projector");
   // Advertise all published topics
 
   // Prevent connection callbacks from executing until we've set all the publishers. Otherwise
@@ -183,6 +184,7 @@ void AstraDriver::advertiseROSTopics()
     ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::depthConnectCb, this);
     pub_depth_raw_ = depth_it.advertiseCamera("image_raw", 1, itssc, itssc, rssc, rssc);
     pub_depth_ = depth_raw_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
+    pub_projector_info_ = projector_nh.advertise<sensor_msgs::CameraInfo>("camera_info", 1, rssc, rssc);
   }
 
   ////////// CAMERA INFO MANAGER
@@ -418,6 +420,7 @@ void AstraDriver::depthConnectCb()
 
   depth_subscribers_ = pub_depth_.getNumSubscribers() > 0;
   depth_raw_subscribers_ = pub_depth_raw_.getNumSubscribers() > 0;
+  projector_info_subscribers_ = pub_projector_info_.getNumSubscribers() > 0;
 
   bool need_depth = depth_subscribers_ || depth_raw_subscribers_;
 
@@ -502,7 +505,7 @@ void AstraDriver::newDepthFrameCallback(sensor_msgs::ImagePtr image)
 
     data_skip_depth_counter_ = 0;
 
-    if (depth_raw_subscribers_||depth_subscribers_)
+    if (depth_raw_subscribers_||depth_subscribers_||projector_info_subscribers_)
     {
       image->header.stamp = image->header.stamp + depth_time_offset_;
 
@@ -543,6 +546,12 @@ void AstraDriver::newDepthFrameCallback(sensor_msgs::ImagePtr image)
       {
         sensor_msgs::ImageConstPtr floating_point_image = rawToFloatingPointConversion(image);
         pub_depth_.publish(floating_point_image, cam_info);
+      }
+
+      // Projector "info" probably only useful for working with disparity images
+      if (projector_info_subscribers_)
+      {
+        pub_projector_info_.publish(getProjectorCameraInfo(image->width, image->height, image->header.stamp));
       }
     }
   }
@@ -654,6 +663,17 @@ sensor_msgs::CameraInfoPtr AstraDriver::getDepthCameraInfo(int width, int height
   info->P[6] -= depth_ir_offset_y_*scaling; // cy
 
   /// @todo Could put this in projector frame so as to encode the baseline in P[3]
+  return info;
+}
+
+sensor_msgs::CameraInfoPtr AstraDriver::getProjectorCameraInfo(int width, int height, ros::Time time) const
+{
+  // The projector info is simply the depth info with the baseline encoded in the P matrix.
+  // It's only purpose is to be the "right" camera info to the depth camera's "left" for
+  // processing disparity images.
+  sensor_msgs::CameraInfoPtr info = getDepthCameraInfo(width, height, time);
+  // Tx = -baseline * fx
+  info->P[3] = -device_->getBaseline() * info->P[0];
   return info;
 }
 


### PR DESCRIPTION
Both `freenect_camera` and `openni_camera` publish the topic `/camera/projector/camera_info`, but `openni2_camera` and `astra_camera` didn't. This commit fixes that.

The topic is required for the disparity image to work (see ros-drivers/rgbd_launch#6). This commit is a port from the original openni_camera driver.

How to test:

    roslaunch astra_launch astra.launch disparity_processing:=true
    rosrun image_view disparity_view image:=/camera/depth/disparity

or:

    roslaunch astra_launch astra.launch depth_registration:=true disparity_registered_processing:=true
    rosrun image_view disparity_view image:=/camera/depth_registered/disparity

See https://github.com/ros-drivers/openni2_camera/pull/48