### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/ros/astra_camera_nodelet.cpp
+++ b/ros/astra_camera_nodelet.cpp
@@ -55,4 +55,4 @@ private:
 }
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(astra_camera, AstraDriverNodelet, astra_camera::AstraDriverNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(astra_camera::AstraDriverNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions