### PR TITLE
Select video mode (ir/rgb/auto) preference with dynamic reconfigure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,16 +2,6 @@
 Changelog for package astra_camera
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.2.1 (2018-02-12)
------------
-* 1,patch for catkin_make -j1 in docker 2,patch for x64 use x86 in docker 3,arm/arm64 use no-filter library
-* Contributors: Tim
-
-0.2.0 (2018-01-25)
-------------------
-* add support for astra mini s
-* Contributors: Tim Liu
-
 0.1.5 (2016-05-27)
 ------------------
 * add dependency on generated messages to avoid race condition at build time

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package astra_camera
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+-0.2.1 (2018-02-12)	
+------------	
+-* 1,patch for catkin_make -j1 in docker 2,patch for x64 use x86 in docker 3,arm/arm64 use no-filter library	
+-* Contributors: Tim	
+-	
+-0.2.0 (2018-01-25)	
+-------------------	
+-* add support for astra mini s	
+-* Contributors: Tim Liu	
+-
 0.1.5 (2016-05-27)
 ------------------
 * add dependency on generated messages to avoid race condition at build time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,27 +5,7 @@ find_package(catkin REQUIRED camera_info_manager dynamic_reconfigure image_trans
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
-if(MSVC64 OR MINGW64)
-  set(X86_64 1)
-elseif(MINGW OR (MSVC AND NOT CMAKE_CROSSCOMPILING))
-  set(X86 1)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
-  set(X86_64 1)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i686.*|i386.*|x86.*|amd64.*|AMD64.*")
-  set(X86 1)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
-  set(ARM 1)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)")
-  set(AARCH64 1)
-endif()
-
-if(ARM OR AARCH64)
-  option(FILTER "OB Filter library" OFF)
-else()
-  option(FILTER "OB Filter library" ON)
-endif()
-
-message(STATUS "arm is ${ARM}, aarch is ${AARCH64}, x86 is ${X86}, x64 is ${X86_64}, filter is ${FILTER}")
+option(FILTER "OB Filter library" ON)
 
 if( ${FILTER} STREQUAL "ON" )
 set(obfilter "On")
@@ -41,6 +21,7 @@ ExternalProject_Add(astra_openni2
   GIT_REPOSITORY https://github.com/orbbec/OpenNI2.git
   GIT_TAG orbbec_ros
   CONFIGURE_COMMAND echo "no need to configure"
+  #${CMAKE_CURRENT_SOURCE_DIR}/libantlr/configure --prefix=<INSTALL_DIR>
   BUILD_IN_SOURCE 1
   BUILD_COMMAND make release FILTER=${obfilter}
   INSTALL_DIR openni2
@@ -56,7 +37,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES astra_wrapper
   CATKIN_DEPENDS camera_info_manager dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_runtime
-  #DEPENDS libastra
+  DEPENDS libastra
 )
 
 link_directories(${CMAKE_CURRENT_BINARY_DIR}/openni2/Redist)
@@ -80,7 +61,7 @@ add_library(astra_wrapper
 )
 target_link_libraries(astra_wrapper ${catkin_LIBRARIES} -lOpenNI2Orbbec
   ${Boost_LIBRARIES} )
-add_dependencies(astra_wrapper ${PROJECT_NAME}_gencfg astra_openni2 ${PROJECT_NAME}_generate_messages_cpp)
+add_dependencies(astra_wrapper astra_openni2 ${PROJECT_NAME}_generate_messages_cpp)
 
 add_library(astra_driver_lib
                 src/astra_driver.cpp

--- a/cfg/Astra.cfg
+++ b/cfg/Astra.cfg
@@ -21,6 +21,12 @@ output_mode_enum = gen.enum([  gen.const(  "SXGA_30Hz", int_t, 1,  "1280x1024@30
                                gen.const( "QQVGA_60Hz", int_t, 12, "160x120@60Hz")],
                                "output mode")
 
+video_type_enum = gen.enum([  gen.const(  "Default", int_t, 0,  "Normal video mode"),
+                              gen.const(  "IR", int_t, 1,  "IR video mode"),
+                              gen.const(   "RGB", int_t, 2,  "RGB video mode")],
+                              "output mode")
+
+gen.add("camera_override_mode", int_t, 0, "Override video type; 0=default, 1=IR, 2=RGB", 0, 0, 2, edit_method = video_type_enum)
 
 gen.add("ir_mode", int_t, 0, "Video mode for IR camera", 5, 1, 12, edit_method = output_mode_enum)
 gen.add("color_mode", int_t, 0, "Video mode for color camera", 5, 1, 12, edit_method = output_mode_enum)

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -163,6 +163,11 @@ private:
   int data_skip_color_counter_;
   int data_skip_depth_counter_;
 
+  int camera_override_mode_;
+  static const int AUTO = 0;
+  static const int IR = 1;
+  static const int RGB = 2;
+
   bool auto_exposure_;
   bool auto_white_balance_;
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>astra_camera</name>
-  <version>0.2.1</version>
+  <version>0.2.0</version>
   <description>Drivers for Orbbec Astra Devices. </description>
   <author email="liuhua@orbbec.com">Tim Liu</author>
   <license>BSD</license>


### PR DESCRIPTION
I found that not being able to select the preferred video mode (ir or rgb) somewhat annoying

I added a reconfigure option to select a preferred mode (IR, RGB, or AUTO)

IR: If this mode is selected and there are subscribers, will publish IR stream
RGB: Same as above, except for RGB
AUTO: No change in behavior