### PR TITLE
Added reconfigurable video mode (RGB, IR)

### DIFF
--- a/cfg/Astra.cfg
+++ b/cfg/Astra.cfg
@@ -21,6 +21,11 @@ output_mode_enum = gen.enum([  gen.const(  "SXGA_30Hz", int_t, 1,  "1280x1024@30
                                gen.const( "QQVGA_60Hz", int_t, 12, "160x120@60Hz")],
                                "output mode")
 
+video_stream_enum = gen.enum([  gen.const(  "RGB", bool_t, True,  "RGB video stream preferred"),
+                                gen.const(  "IR", bool_t, False,  "IR video stream preferred")],
+                                "preferred video stream mode")
+
+gen.add("rgb_preferred", bool_t, 0, "Preferred camera stream", True, edit_method = video_stream_enum)
 
 gen.add("ir_mode", int_t, 0, "Video mode for IR camera", 5, 1, 12, edit_method = output_mode_enum)
 gen.add("color_mode", int_t, 0, "Video mode for color camera", 5, 1, 12, edit_method = output_mode_enum)

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -86,9 +86,8 @@ private:
 
   void advertiseROSTopics();
 
-  void colorConnectCb();
+  void imageConnectCb();
   void depthConnectCb();
-  void irConnectCb();
 
   bool getSerialCb(astra_camera::GetSerialRequest& req, astra_camera::GetSerialResponse& res);
 
@@ -162,6 +161,8 @@ private:
   int data_skip_ir_counter_;
   int data_skip_color_counter_;
   int data_skip_depth_counter_;
+
+  bool rgb_preferred_;
 
   bool auto_exposure_;
   bool auto_white_balance_;

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -165,15 +165,15 @@ void AstraDriver::advertiseROSTopics()
   //ROS_WARN("-------------has color sensor is %d----------- ", device_->hasColorSensor());
   if (device_->hasColorSensor())
   {
-    image_transport::SubscriberStatusCallback itssc = boost::bind(&AstraDriver::colorConnectCb, this);
-    ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::colorConnectCb, this);
+    image_transport::SubscriberStatusCallback itssc = boost::bind(&AstraDriver::imageConnectCb, this);
+    ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::imageConnectCb, this);
     pub_color_ = color_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
   }
 
   if (device_->hasIRSensor())
   {
-    image_transport::SubscriberStatusCallback itssc = boost::bind(&AstraDriver::irConnectCb, this);
-    ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::irConnectCb, this);
+    image_transport::SubscriberStatusCallback itssc = boost::bind(&AstraDriver::imageConnectCb, this);
+    ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::imageConnectCb, this);
     pub_ir_ = ir_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
   }
 
@@ -217,6 +217,11 @@ bool AstraDriver::getSerialCb(astra_camera::GetSerialRequest& req, astra_camera:
 void AstraDriver::configCb(Config &config, uint32_t level)
 {
   bool stream_reset = false;
+
+  rgb_preferred_ = config.rgb_preferred;
+
+  if (config_init_ && old_config_.rgb_preferred != config.rgb_preferred)
+    imageConnectCb();
 
   depth_ir_offset_x_ = config.depth_ir_offset_x;
   depth_ir_offset_y_ = config.depth_ir_offset_y;
@@ -373,41 +378,66 @@ void AstraDriver::applyConfigToOpenNIDevice()
 
 }
 
-void AstraDriver::colorConnectCb()
+void AstraDriver::imageConnectCb()
 {
   boost::lock_guard<boost::mutex> lock(connect_mutex_);
 
+  bool ir_started = device_->isIRStreamStarted();
+  bool color_started = device_->isColorStreamStarted();
+
+  ir_subscribers_ = pub_ir_.getNumSubscribers() > 0;
   color_subscribers_ = pub_color_.getNumSubscribers() > 0;
 
-  if (color_subscribers_ && !device_->isColorStreamStarted())
+  if (color_subscribers_ && (!ir_subscribers_ || rgb_preferred_))
   {
-    // Can't stream IR and RGB at the same time. Give RGB preference.
-    if (device_->isIRStreamStarted())
-    {
+    if (ir_subscribers_)
       ROS_ERROR("Cannot stream RGB and IR at the same time. Streaming RGB only.");
+
+    if (ir_started)
+    {
       ROS_INFO("Stopping IR stream.");
       device_->stopIRStream();
     }
 
-    device_->setColorFrameCallback(boost::bind(&AstraDriver::newColorFrameCallback, this, _1));
+    if (!color_started)
+    {
+      device_->setColorFrameCallback(boost::bind(&AstraDriver::newColorFrameCallback, this, _1));
 
-    ROS_INFO("Starting color stream.");
-    device_->startColorStream();
-
+      ROS_INFO("Starting color stream.");
+      device_->startColorStream();
+    }
   }
-  else if (!color_subscribers_ && device_->isColorStreamStarted())
+  else if (ir_subscribers_ && (!color_subscribers_ || !rgb_preferred_))
   {
-    ROS_INFO("Stopping color stream.");
-    device_->stopColorStream();
 
-    // Start IR if it's been blocked on RGB subscribers
-    bool need_ir = pub_ir_.getNumSubscribers() > 0;
-    if (need_ir && !device_->isIRStreamStarted())
+    if (color_subscribers_)
+      ROS_ERROR("Cannot stream RGB and IR at the same time. Streaming IR only.");
+
+    if (color_started)
+    {
+      ROS_INFO("Stopping color stream.");
+      device_->stopColorStream();
+    }
+
+    if (!ir_started)
     {
       device_->setIRFrameCallback(boost::bind(&AstraDriver::newIRFrameCallback, this, _1));
 
       ROS_INFO("Starting IR stream.");
       device_->startIRStream();
+    }
+  }
+  else
+  {
+    if (color_started)
+    {
+      ROS_INFO("Stopping color stream.");
+      device_->stopColorStream();
+    }
+    if (ir_started)
+    {
+      ROS_INFO("Stopping IR stream.");
+      device_->stopIRStream();
     }
   }
 }
@@ -432,34 +462,6 @@ void AstraDriver::depthConnectCb()
   {
     ROS_INFO("Stopping depth stream.");
     device_->stopDepthStream();
-  }
-}
-
-void AstraDriver::irConnectCb()
-{
-  boost::lock_guard<boost::mutex> lock(connect_mutex_);
-
-  ir_subscribers_ = pub_ir_.getNumSubscribers() > 0;
-
-  if (ir_subscribers_ && !device_->isIRStreamStarted())
-  {
-    // Can't stream IR and RGB at the same time
-    if (device_->isColorStreamStarted())
-    {
-      ROS_ERROR("Cannot stream RGB and IR at the same time. Streaming RGB only.");
-    }
-    else
-    {
-      device_->setIRFrameCallback(boost::bind(&AstraDriver::newIRFrameCallback, this, _1));
-
-      ROS_INFO("Starting IR stream.");
-      device_->startIRStream();
-    }
-  }
-  else if (!ir_subscribers_ && device_->isIRStreamStarted())
-  {
-    ROS_INFO("Stopping IR stream.");
-    device_->stopIRStream();
   }
 }
 


### PR DESCRIPTION
By default, if both RGB and IR image topics are subscribed to by another node, the camera driver prioritizes the RGB request. There are times, however, when it might be useful to prioritize the IR channel, such as during depthcam/IR camera calibration. These times are likely few and far between, so I think that the current default of prioritizing the RGB stream when there is a conflict makes sense.

However, I've added a dynamic reconfigurable option to specify the video mode preference. The mode defaults to the current RGB preference, but allows an IR preference if desired. The behavior is otherwise the same; if the IR stream is preferred, but there are no IR image subscribers and there are RGB image subscribers, then video stream will switch RGB.

I suggest rebasing to master branch when merging, as we are using an older version of ros_astra_camera