### PR TITLE
Cleanup: Remove duplicate getParam calls

### DIFF
--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -67,9 +67,6 @@ AstraDriver::AstraDriver(ros::NodeHandle& n, ros::NodeHandle& pnh) :
 
 #if MULTI_ASTRA
 	int bootOrder, devnums;
-	pnh.getParam("bootorder", bootOrder);
-	pnh.getParam("devnums", devnums);
-  
   if (!pnh.getParam("bootorder", bootOrder))
   {
     bootOrder = 0;


### PR DESCRIPTION
The parameters "bootorder" and "devnums" were retrieved twice: Once in
the removed lines, then again immediately below. This removes the
unnecessary first lines to clean up the code.