### PR TITLE
Update ir/depth pixel shift ranges to include observations for Astra Mini S

### DIFF
--- a/cfg/Astra.cfg
+++ b/cfg/Astra.cfg
@@ -42,8 +42,8 @@ gen.add("ir_time_offset", double_t, 0, "ir image time offset in seconds", -0.033
 gen.add("color_time_offset", double_t, 0, "color image time offset in seconds", -0.033, -1.0, 1.0 );
 gen.add("depth_time_offset", double_t, 0, "depth image time offset in seconds", -0.033, -1.0, 1.0 );
 
-gen.add("depth_ir_offset_x", double_t, 0, "X offset between IR and depth images", 5.0, -10.0, 10.0)
-gen.add("depth_ir_offset_y", double_t, 0, "Y offset between IR and depth images", 4.0, -10.0, 10.0)
+gen.add("depth_ir_offset_x", double_t, 0, "X offset between IR and depth images", 5.0, -20.0, 20.0)
+gen.add("depth_ir_offset_y", double_t, 0, "Y offset between IR and depth images", 4.0, -20.0, 20.0)
 
 gen.add("z_offset_mm", int_t, 0, "Z offset in mm", 0, -200, 200)
 gen.add("z_scaling", double_t, 0, "Scaling factor for depth values", 1.0, 0.5, 1.5)


### PR DESCRIPTION
I have observed that the IR/depth shift at VGA (640x480) for the Astra Mini S is  as follows:

`depth_ir_offset_x`: 1
`depth_ir_offset_y`: 14

This observation has been consistent across three Astra Mini S depthcameras. The current range for these paramers in Astra.cfg is thresholded between -10 and 10 pixels, which prevents setting `depth_ir_offset_y` to the correct value.