### PR TITLE
melodic fix for build error where warnings are errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ ExternalProject_Add(astra_openni2
   GIT_TAG orbbec_ros
   CONFIGURE_COMMAND echo "no need to configure"
   BUILD_IN_SOURCE 1
-  BUILD_COMMAND make release FILTER=${obfilter}
+  BUILD_COMMAND make release FILTER=${obfilter} ALLOW_WARNINGS=1
   INSTALL_DIR openni2
   INSTALL_COMMAND tar -xjf <SOURCE_DIR>/Packaging/Final/OpenNI-Linux-2.3.tar.bz2 -C <INSTALL_DIR> --strip 1 && mkdir -p <INSTALL_DIR>/include && ln -fs <INSTALL_DIR>/Include <INSTALL_DIR>/include/openni2
 )


### PR DESCRIPTION
While trying to build on ubuntu 18.04, received this error
```
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
ThirdParty/PSCommon/BuildSystem/CommonDefs.mak:40: HOST_PLATFORM is x64
../../BuildSystem/CommonDefs.mak:40: HOST_PLATFORM is x64
../../ThirdParty/PSCommon/BuildSystem/CommonDefs.mak:40: HOST_PLATFORM is x64
../../ThirdParty/PSCommon/BuildSystem/CommonDefs.mak:40: HOST_PLATFORM is x64
../../../ThirdParty/PSCommon/BuildSystem/CommonDefs.mak:40: HOST_PLATFORM is x64
Formats/XnFormatsMirror.cpp: In function ‘XnStatus XnMirrorOneBytePixels(XnUChar*, XnUInt32, XnUInt32)’:
Formats/XnFormatsMirror.cpp:46:11: error: array subscript is below array bounds [-Werror=array-bounds]
  XnUInt8* pDestEnd = &pLineBuffer[0] - 1;
           ^~~~~~~~
Formats/XnFormatsMirror.cpp: In function ‘XnStatus XnMirrorTwoBytePixels(XnUChar*, XnUInt32, XnUInt32)’:
Formats/XnFormatsMirror.cpp:79:12: error: array subscript is below array bounds [-Werror=array-bounds]
  XnUInt16* pDestEnd = &pLineBuffer[0] - 1;
            ^~~~~~~~
Formats/XnFormatsMirror.cpp: In function ‘XnStatus XnMirrorThreeBytePixels(XnUChar*, XnUInt32, XnUInt32)’:
Formats/XnFormatsMirror.cpp:115:11: error: array subscript is below array bounds [-Werror=array-bounds]
  XnUInt8* pDestEnd = &pLineBuffer[0] - 1;
           ^~~~~~~~
cc1plus: all warnings being treated as errors
make[4]: *** [../../../Bin/Intermediate/x64-Release/liborbbec.so/XnFormatsMirror.o] Error 1
make[3]: *** [Source/Drivers/orbbec] Error 2
make[2]: *** [astra_openni2/src/astra_openni2-stamp/astra_openni2-build] Error 2
make[1]: *** [CMakeFiles/astra_openni2.dir/all] Error 2
make: *** [all] Error 2

```
