### PR TITLE
Added manual exposure. Fixed color HD resolution

### DIFF
--- a/cfg/Astra.cfg
+++ b/cfg/Astra.cfg
@@ -7,8 +7,8 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 # TODO Only offer modes supported by known hardware
-output_mode_enum = gen.enum([  gen.const(  "SXGA_30Hz", int_t, 1,  "1280x1024@30Hz"),
-                               gen.const(  "SXGA_15Hz", int_t, 2,  "1280x1024@15Hz"),
+output_mode_enum = gen.enum([  gen.const(  "SXGA_30Hz", int_t, 1,  "1280x960@30Hz"),
+                               gen.const(  "SXGA_15Hz", int_t, 2,  "1280x960@15Hz"),
                                gen.const(   "XGA_30Hz", int_t, 3,  "1280x720@30Hz"),
                                gen.const(   "XGA_15Hz", int_t, 4,  "1280x720@15Hz"),
                                gen.const(   "VGA_30Hz", int_t, 5,  "640x480@30Hz"),
@@ -35,6 +35,7 @@ gen.add("depth_registration", bool_t, 0, "Depth data registration", True)
 gen.add("color_depth_synchronization", bool_t, 0, "Synchronization of color and depth camera", False)
 gen.add("auto_exposure", bool_t, 0, "Auto-Exposure", True)
 gen.add("auto_white_balance", bool_t, 0, "Auto-White-Balance", True)
+gen.add("manual_exposure", int_t, 0, "Manual-Exposure", 100, 0, 500)
 
 gen.add("data_skip",  int_t, 0, "Skip N images for every image published (rgb/depth/depth_registered/ir)", 0, 0, 10)
 

--- a/include/astra_camera/astra_device.h
+++ b/include/astra_camera/astra_device.h
@@ -127,6 +127,7 @@ public:
 
   void setAutoExposure(bool enable) throw (AstraException);
   void setAutoWhiteBalance(bool enable) throw (AstraException);
+  void setManualExposure(int exposure) throw (AstraException);
 
   bool getAutoExposure() const;
   bool getAutoWhiteBalance() const;

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -167,6 +167,7 @@ private:
 
   bool auto_exposure_;
   bool auto_white_balance_;
+  int manual_exposure_;
 
   bool ir_subscribers_;
   bool color_subscribers_;

--- a/src/astra_device.cpp
+++ b/src/astra_device.cpp
@@ -560,6 +560,21 @@ void AstraDevice::setAutoWhiteBalance(bool enable) throw (AstraException)
   }
 }
 
+void AstraDevice::setManualExposure(int exposure) throw (AstraException)
+{
+  boost::shared_ptr<openni::VideoStream> stream = getColorVideoStream();
+
+  if (stream)
+  {
+    openni::CameraSettings* camera_seeting = stream->getCameraSettings();
+    if (camera_seeting)
+    {
+      if ( camera_seeting->setAutoExposureEnabled(false) != openni::STATUS_OK || camera_seeting->setExposure(exposure) != openni::STATUS_OK )
+        THROW_OPENNI_EXCEPTION("Couldn't set manual exposure: \n%s\n", openni::OpenNI::getExtendedError());
+    }
+  }
+}
+
 bool AstraDevice::getAutoExposure() const
 {
   bool ret = false;

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -275,6 +275,7 @@ void AstraDriver::configCb(Config &config, uint32_t level)
 
   auto_exposure_ = config.auto_exposure;
   auto_white_balance_ = config.auto_white_balance;
+  manual_exposure_ = config.manual_exposure;
 
   use_device_time_ = config.use_device_time;
 
@@ -386,6 +387,16 @@ void AstraDriver::applyConfigToOpenNIDevice()
   catch (const AstraException& exception)
   {
     ROS_ERROR("Could not set auto white balance. Reason: %s", exception.what());
+  }
+
+  try
+  {
+    if ( !auto_exposure_ && (!config_init_ || (old_config_.manual_exposure != manual_exposure_))) // only if auto_exposure is OFF
+      device_->setManualExposure(manual_exposure_);
+  }
+  catch (const AstraException& exception)
+  {
+    ROS_ERROR("Could not set manual exposure=%d. Reason: %s", manual_exposure_, exception.what());
   }
 
   device_->setUseDeviceTimer(use_device_time_);
@@ -896,8 +907,8 @@ void AstraDriver::genVideoModeTableMap()
 {
   /*
    * #  Video modes defined by dynamic reconfigure:
-output_mode_enum = gen.enum([  gen.const(  "SXGA_30Hz", int_t, 1,  "1280x1024@30Hz"),
-                               gen.const(  "SXGA_15Hz", int_t, 2,  "1280x1024@15Hz"),
+output_mode_enum = gen.enum([  gen.const(  "SXGA_30Hz", int_t, 1,  "1280x960@30Hz"),
+                               gen.const(  "SXGA_15Hz", int_t, 2,  "1280x960@15Hz"),
                                gen.const(   "XGA_30Hz", int_t, 3,  "1280x720@30Hz"),
                                gen.const(   "XGA_15Hz", int_t, 4,  "1280x720@15Hz"),
                                gen.const(   "VGA_30Hz", int_t, 5,  "640x480@30Hz"),
@@ -917,14 +928,14 @@ output_mode_enum = gen.enum([  gen.const(  "SXGA_30Hz", int_t, 1,  "1280x1024@30
 
   // SXGA_30Hz
   video_mode.x_resolution_ = 1280;
-  video_mode.y_resolution_ = 1024;
+  video_mode.y_resolution_ = 960;
   video_mode.frame_rate_ = 30;
 
   video_modes_lookup_[1] = video_mode;
 
   // SXGA_15Hz
   video_mode.x_resolution_ = 1280;
-  video_mode.y_resolution_ = 1024;
+  video_mode.y_resolution_ = 960;
   video_mode.frame_rate_ = 15;
 
   video_modes_lookup_[2] = video_mode;


### PR DESCRIPTION
Driver update to match MX6000 firmware update released 2018.05.18 (MD5 : 03914b44fafb756ed62b7cf78aae9d8e)

* added support for manual exposure control
* fixed HD color resolution to 1024x960 instead of 1024x1024 