### PR TITLE
Add missing dependency on generated header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(astra_wrapper
 )
 target_link_libraries(astra_wrapper ${catkin_LIBRARIES} -lOpenNI2  -L${ORRBEC_OPENNI2_REDIST}
   ${Boost_LIBRARIES} )
+add_dependencies(astra_wrapper ${catkin_EXPORTED_TARGETS})
 
 add_library(astra_driver_lib
                 src/astra_driver.cpp


### PR DESCRIPTION
Specifically the GetSerial.h is generated from the srv file and is
needed by astra_driver.h. Without this there is nothing to ensure that
GetSerial.h is generated before the code that uses it gets compiled and
can fail as follows:
Errors     << astra_camera:make .../build/logs/astra_camera/build.make.000.log
In file included from
.../build/src/ros_astra_camera/src/astra_device.cpp:39:0:
.../build/src/ros_astra_camera/include/astra_camera/astra_driver.h:55:36:
fatal error: astra_camera/GetSerial.h: No such file or directory