### PR TITLE
astra_driver: add destructor to stop all streams

### DIFF
--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -63,6 +63,7 @@ class AstraDriver
 {
 public:
   AstraDriver(ros::NodeHandle& n, ros::NodeHandle& pnh) ;
+  ~AstraDriver();
 
 private:
   typedef astra_camera::AstraConfig Config;

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -141,6 +141,10 @@ AstraDriver::AstraDriver(ros::NodeHandle& n, ros::NodeHandle& pnh) :
 
 }
 
+AstraDriver::~AstraDriver() {
+  device_->stopAllStreams();
+}
+
 void AstraDriver::advertiseROSTopics()
 {
 


### PR DESCRIPTION
This has registered callbacks with the streams so if they are not
stopped they may still call back in with an object that has been
destroyed, which will cause an invalid access.