### PR TITLE
install commands were x64-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,11 +147,11 @@ install(TARGETS astra_wrapper astra_camera_nodelet astra_camera_node astra_list_
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   )
 
-install(FILES include/openni2_redist/x64/libOpenNI2.so
+install(FILES include/openni2_redist/${HOST_PLATFORM}/libOpenNI2.so
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}/
 )
 
-install(DIRECTORY include/openni2_redist/x64/OpenNI2
+install(DIRECTORY include/openni2_redist/${HOST_PLATFORM}/OpenNI2
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}/
 )
 


### PR DESCRIPTION
compilation did already depend on ${HOST_PLATFORM}, but the x64-libs were installed for all platforms