### PR TITLE
Fix libuvc depends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ ENDIF ()
 message(STATUS "ORRBEC : ${HOST_PLATFORM}")
 message(STATUS "libuvc ${libuvc_VERSION_MAJOR}.${libuvc_VERSION_MINOR}.${libuvc_VERSION_PATCH}")
 
-generate_dynamic_reconfigure_options(cfg/Astra.cfg)
+generate_dynamic_reconfigure_options(cfg/Astra.cfg cfg/UVCCamera.cfg)
 
 add_service_files(
   FILES

--- a/include/libuvc_camera/camera_driver.h
+++ b/include/libuvc_camera/camera_driver.h
@@ -16,7 +16,7 @@
 #include <astra_camera/GetUVCWhiteBalance.h>
 #include <astra_camera/SetUVCWhiteBalance.h>
 #include <astra_camera/astra_device_type.h>
-#include <libuvc_camera/UVCCameraConfig.h>
+#include <astra_camera/UVCCameraConfig.h>
 
 #include <string>
 

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>libuvc</build_depend>
 
   <run_depend>camera_info_manager</run_depend>
   <run_depend>nodelet</run_depend>


### PR DESCRIPTION
libuvc is needed to build so it needs to be added to the build dependencies in package.xml. Additionally the uvc config file needs to be processed and used.