### PR TITLE
Add rgbd_launch dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>rgbd_launch</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/astra_nodelets.xml"/>


### PR DESCRIPTION
rgbd_launch is included in some of the launch files. This change makes rosdep install rgbd_launch automatically as a dependency, so a user doesn't incur in an error if the package is not installed (provided he ran rosdep install).