### PR TITLE
Add source step needed for roscd and script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This package supports ROS Kinetic and Melodic.
     mkdir -p ~/catkin_ws/src
 	cd ~/catkin_ws/
 	catkin_make
+	source devel/setup.bash
     ```
 	
 4. Pull the repository into your ROS workspace


### PR DESCRIPTION
Add:
```sh
source devel/setup.bash
```
which is necessary to be able to *roscd* into *astra_camera* and be able to run script to create udev rules.