### PR TITLE
Automatically install udev rules

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+LOCAL_UDEV_RULE="/etc/udev/rules.d/56-orbbec-usb.rules"
+
+case "$1" in
+    configure)
+        if [ -f ${LOCAL_UDEV_RULE} ]; then
+            echo "WARNING: Locally installed udev rule should removed:" 1>&2
+            echo "         sudo rm -f ${LOCAL_UDEV_RULE}" 1>&2
+	fi
+    ;;
+
+    abort-upgrade|abort-deconfigure|abort-remove)
+    ;;
+
+    *)
+        echo "$0 called with unknown argument \`$1'" 1>&2
+        exit 1
+    ;;
+esac
+
+#DEBHELPER#

--- a/debian/udev
+++ b/debian/udev
@@ -1,0 +1,1 @@
+../56-orbbec-usb.rules


### PR DESCRIPTION
This PR will enable the Debian package generated by the buildfarm to automatically install the udev rules into `/lib/udev/rules.d/60-ros-kinetic-astra-camera.rules`

Tested locally on 16.04 + ROS Kinetic with
```
bloom-generate rosdebian --os-name ubuntu --os-version xenial --ros-distro kinetic --place-template-files
bloom-generate rosdebian --os-name ubuntu --os-version xenial --ros-distro kinetic --process-template-files
debuild -i -us -uc -b
```