### PR TITLE
Saving scoped_lock to local variable to hold lock during critical sec…

### DIFF
--- a/src/libuvc_camera/camera_driver.cpp
+++ b/src/libuvc_camera/camera_driver.cpp
@@ -171,7 +171,7 @@ bool CameraDriver::Start() {
 }
 
 void CameraDriver::Stop() {
-  boost::recursive_mutex::scoped_lock(mutex_);
+  boost::recursive_mutex::scoped_lock lock(mutex_);
 
   assert(state_ != kInitial);
 
@@ -187,7 +187,7 @@ void CameraDriver::Stop() {
 }
 
 void CameraDriver::ReconfigureCallback(UVCCameraConfig &new_config, uint32_t level) {
-  boost::recursive_mutex::scoped_lock(mutex_);
+  boost::recursive_mutex::scoped_lock lock(mutex_);
 
   if ((level & kReconfigureClose) == kReconfigureClose) {
     if (state_ == kRunning)
@@ -254,7 +254,7 @@ void CameraDriver::ImageCallback(uvc_frame_t *frame) {
     timestamp = ros::Time::now();
   }
 
-  boost::recursive_mutex::scoped_lock(mutex_);
+  boost::recursive_mutex::scoped_lock lock(mutex_);
 
   assert(state_ == kRunning);
   assert(rgb_frame_);
@@ -411,7 +411,7 @@ void CameraDriver::AutoControlsCallback(
   int selector,
   enum uvc_status_attribute status_attribute,
   void *data, size_t data_len) {
-  boost::recursive_mutex::scoped_lock(mutex_);
+  boost::recursive_mutex::scoped_lock lock(mutex_);
 
   printf("Controls callback. class: %d, event: %d, selector: %d, attr: %d, data_len: %zu\n",
          status_class, event, selector, status_attribute, data_len);


### PR DESCRIPTION
Saving scoped_lock to local variable to hold lock during critical sections in libuvc_camera/camera_driver.cpp, addressing issue #99