### PR TITLE
Add Tf prefix to Astra Pro

### DIFF
--- a/include/libuvc_camera/camera_driver.h
+++ b/include/libuvc_camera/camera_driver.h
@@ -88,7 +88,6 @@ private:
   bool config_changed_;
 
   camera_info_manager::CameraInfoManager cinfo_manager_;
-  bool param_init_;
   std::string ns;
   std::string ns_no_slash;
 

--- a/launch/astrapro.launch
+++ b/launch/astrapro.launch
@@ -3,9 +3,12 @@
 
   <!-- "camera" should uniquely identify the device. All topics are pushed down
        into the "camera" namespace, and it is prepended to tf frame ids. -->
-  <arg name="camera" default="camera" />
-  <arg name="rgb_frame_id"   default="$(arg camera)_rgb_optical_frame" />
-  <arg name="depth_frame_id" default="$(arg camera)_depth_optical_frame" />
+  <arg name="camera"    default="camera" />
+  <arg name="tf_prefix" default="" />
+  <arg name="rgb_frame_id"   if="$(eval arg('tf_prefix') == '')" default="$(arg camera)_rgb_optical_frame" />
+  <arg name="depth_frame_id" if="$(eval arg('tf_prefix') == '')" default="$(arg camera)_depth_optical_frame" />
+  <arg name="rgb_frame_id"   unless="$(eval arg('tf_prefix') == '')" default="$(arg tf_prefix)/$(arg camera)_rgb_optical_frame" />
+  <arg name="depth_frame_id" unless="$(eval arg('tf_prefix') == '')" default="$(arg tf_prefix)/$(arg camera)_depth_optical_frame" />
 
   <!-- device_id can have the following formats:
          "#n"            : the nth device found, starts from 1
@@ -138,6 +141,7 @@
   <include if="$(arg publish_tf)"
 	   file="$(find astra_camera)/launch/includes/astra_frames.launch">
     <arg name="camera" value="$(arg camera)" />
+    <arg name="tf_prefix" value="$(arg tf_prefix)"/>
   </include>
 
 </launch>

--- a/src/libuvc_camera/camera_driver.cpp
+++ b/src/libuvc_camera/camera_driver.cpp
@@ -56,8 +56,7 @@ CameraDriver::CameraDriver(ros::NodeHandle nh, ros::NodeHandle priv_nh)
     it_(nh_),
     config_server_(mutex_, priv_nh_),
     config_changed_(false),
-    cinfo_manager_(nh),
-    param_init_(false) {
+    cinfo_manager_(nh) {
   cam_pub_ = it_.advertiseCamera("image_raw", 1, false);
   ns = ros::this_node::getNamespace();
   device_type_client = nh_.serviceClient<astra_camera::GetDeviceType>(ns + "/get_device_type");
@@ -122,7 +121,7 @@ bool CameraDriver::getUVCGainCb(astra_camera::GetUVCGainRequest& req, astra_came
   uint16_t gain;
   uvc_error_t err = uvc_get_gain(devh_, &gain, UVC_GET_CUR);
   res.gain = gain;
-  return (err == UVC_SUCCESS); 
+  return (err == UVC_SUCCESS);
 }
 
 bool CameraDriver::setUVCGainCb(astra_camera::SetUVCGainRequest& req, astra_camera::SetUVCGainResponse& res)
@@ -221,7 +220,7 @@ void CameraDriver::ReconfigureCallback(UVCCameraConfig &new_config, uint32_t lev
     PARAM_INT(iris_absolute, iris_abs, new_config.iris_absolute);
     PARAM_INT(brightness, brightness, new_config.brightness);
 #endif
-    
+
 
     if (new_config.pan_absolute != config_.pan_absolute || new_config.tilt_absolute != config_.tilt_absolute) {
       if (uvc_set_pantilt_abs(devh_, new_config.pan_absolute, new_config.tilt_absolute)) {
@@ -434,7 +433,7 @@ void CameraDriver::AutoControlsCallback(
       switch (selector) {
       case UVC_PU_WHITE_BALANCE_TEMPERATURE_CONTROL:
         uint8_t *data_char = (uint8_t*) data;
-        config_.white_balance_temperature = 
+        config_.white_balance_temperature =
           data_char[0] | (data_char[1] << 8);
         config_changed_ = true;
         break;


### PR DESCRIPTION
This PR adds a `tf_prefix` argument in order to append it to `rgb_frame_id` and `depth_frame_id`.