### PR TITLE
[noetic-support] remove hardcoded python2 reference

### DIFF
--- a/cfg/UVCCamera.cfg
+++ b/cfg/UVCCamera.cfg
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python
 # Derived from camera1394 cfg
 
 from dynamic_reconfigure.parameter_generator_catkin import *


### PR DESCRIPTION
Astra.cfg already used `env python`, no idea why UVCCamera was listed for python2 then...

I did not verify any functionality with ROS noetic,
but this patch is needed to compile the package at all.