### PR TITLE
Noetic: Added missing dependencies in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,8 @@
   <depend>image_geometry</depend>
   <depend>image_transport</depend>
   <depend>libudev-dev</depend>
+  <depend>libuvc-dev</depend>
+  <depend>libgoogle-glog-dev</depend>
   <depend>libusb-1.0-dev</depend>
   <depend>message_generation</depend>
   <depend>message_runtime</depend>


### PR DESCRIPTION
I added dependencies to `package.xml`:
- libuvc 
- glog 
Now rosdep install should install missing dependencies.